### PR TITLE
Implement MVVM base structure with Material Design

### DIFF
--- a/Maintenance.Client/App.xaml
+++ b/Maintenance.Client/App.xaml
@@ -3,5 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="Views/MainWindow.xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.Indigo.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Pink.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Maintenance.Client/Commands/RelayCommand.vb
+++ b/Maintenance.Client/Commands/RelayCommand.vb
@@ -1,0 +1,35 @@
+Imports System.Windows.Input
+
+Namespace Maintenance.Client.Commands
+    Public Class RelayCommand
+        Implements ICommand
+
+    Private ReadOnly _execute As Action(Of Object)
+    Private ReadOnly _canExecute As Func(Of Object, Boolean)
+
+    Public Custom Event CanExecuteChanged As EventHandler Implements ICommand.CanExecuteChanged
+        AddHandler(value As EventHandler)
+            AddHandler CommandManager.RequerySuggested, value
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+            RemoveHandler CommandManager.RequerySuggested, value
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+            CommandManager.InvalidateRequerySuggested()
+        End RaiseEvent
+    End Event
+
+    Public Sub New(execute As Action(Of Object), Optional canExecute As Func(Of Object, Boolean) = Nothing)
+        _execute = execute
+        _canExecute = If(canExecute, Function(o) True)
+    End Sub
+
+    Public Function CanExecute(parameter As Object) As Boolean Implements ICommand.CanExecute
+        Return _canExecute(parameter)
+    End Function
+
+    Public Sub Execute(parameter As Object) Implements ICommand.Execute
+        _execute(parameter)
+    End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Services/NavigationService.vb
+++ b/Maintenance.Client/Services/NavigationService.vb
@@ -1,0 +1,23 @@
+Namespace Maintenance.Client.Services
+    Public Class NavigationService
+        Inherits ViewModels.BaseViewModel
+
+    Private _currentViewModel As BaseViewModel
+
+    Public Property CurrentViewModel As BaseViewModel
+        Get
+            Return _currentViewModel
+        End Get
+        Private Set(value As BaseViewModel)
+            If _currentViewModel IsNot value Then
+                _currentViewModel = value
+                OnPropertyChanged()
+            End If
+        End Set
+    End Property
+
+        Public Sub Navigate(viewModel As ViewModels.BaseViewModel)
+            CurrentViewModel = viewModel
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/BaseViewModel.vb
+++ b/Maintenance.Client/ViewModels/BaseViewModel.vb
@@ -1,0 +1,14 @@
+Imports System.ComponentModel
+Imports System.Runtime.CompilerServices
+
+Namespace Maintenance.Client.ViewModels
+    Public MustInherit Class BaseViewModel
+        Implements INotifyPropertyChanged
+
+        Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+
+        Protected Sub OnPropertyChanged(<CallerMemberName> Optional propertyName As String = Nothing)
+            RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs(propertyName))
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/HomeViewModel.vb
+++ b/Maintenance.Client/ViewModels/HomeViewModel.vb
@@ -1,0 +1,19 @@
+Namespace Maintenance.Client.ViewModels
+    Public Class HomeViewModel
+        Inherits BaseViewModel
+
+    Private _message As String = "Benvenuto nella schermata Home"
+
+    Public Property Message As String
+        Get
+            Return _message
+        End Get
+        Set(value As String)
+            If _message <> value Then
+                _message = value
+                OnPropertyChanged()
+            End If
+        End Set
+    End Property
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/MainViewModel.vb
+++ b/Maintenance.Client/ViewModels/MainViewModel.vb
@@ -1,4 +1,14 @@
+Imports Maintenance.Client.Services
+
 Namespace Maintenance.Client.ViewModels
     Public Class MainViewModel
+        Inherits BaseViewModel
+
+        Public ReadOnly Property Navigation As NavigationService
+
+        Public Sub New()
+            Navigation = New NavigationService()
+            Navigation.Navigate(New HomeViewModel())
+        End Sub
     End Class
 End Namespace

--- a/Maintenance.Client/Views/HomeView.xaml
+++ b/Maintenance.Client/Views/HomeView.xaml
@@ -1,0 +1,7 @@
+<UserControl x:Class="Maintenance.Client.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Margin="16">
+        <TextBlock Text="{Binding Message}" FontSize="24" />
+    </Grid>
+</UserControl>

--- a/Maintenance.Client/Views/HomeView.xaml.vb
+++ b/Maintenance.Client/Views/HomeView.xaml.vb
@@ -1,0 +1,11 @@
+Imports System.Windows.Controls
+
+Namespace Maintenance.Client.Views
+    Public Partial Class HomeView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/MainWindow.xaml
+++ b/Maintenance.Client/Views/MainWindow.xaml
@@ -1,7 +1,15 @@
 <Window x:Class="Maintenance.Client.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:Maintenance.Client.Views"
+        xmlns:vm="clr-namespace:Maintenance.Client.ViewModels"
         Title="Maintenance" Height="450" Width="800">
+    <Window.Resources>
+        <DataTemplate DataType="{x:Type vm:HomeViewModel}">
+            <views:HomeView />
+        </DataTemplate>
+    </Window.Resources>
     <Grid>
+        <ContentControl Content="{Binding Navigation.CurrentViewModel}" />
     </Grid>
 </Window>

--- a/Maintenance.Client/Views/MainWindow.xaml.vb
+++ b/Maintenance.Client/Views/MainWindow.xaml.vb
@@ -1,8 +1,13 @@
 Imports System.Windows
-Class MainWindow
-    Inherits Window
+Imports Maintenance.Client.ViewModels
 
-    Public Sub New()
-        InitializeComponent()
-    End Sub
-End Class
+Namespace Maintenance.Client.Views
+    Partial Class MainWindow
+        Inherits Window
+
+        Public Sub New()
+            InitializeComponent()
+            DataContext = New MainViewModel()
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
## Summary
- configure Material Design dictionaries in WPF App
- implement BaseViewModel, RelayCommand and NavigationService
- create HomeView and HomeViewModel example
- update MainViewModel for navigation
- hook MainWindow to view models and views

## Testing
- `dotnet build Maintenance.sln -c Release` *(fails: Could not resolve SDK Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_688372e2cb508327837b03ac93afc4eb