### PR TITLE
Add WCF login window

### DIFF
--- a/Maintenance.Client/App.xaml
+++ b/Maintenance.Client/App.xaml
@@ -1,7 +1,7 @@
 <Application x:Class="Maintenance.Client.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="Views/MainWindow.xaml">
+             StartupUri="Views/LoginWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/Maintenance.Client/Services/IMaintenanceService.vb
+++ b/Maintenance.Client/Services/IMaintenanceService.vb
@@ -1,0 +1,9 @@
+Imports System.ServiceModel
+
+Namespace Maintenance.Client.Services
+    <ServiceContract>
+    Public Interface IMaintenanceService
+        <OperationContract>
+        Function AuthenticateUser(username As String, password As String) As List(Of String)
+    End Interface
+End Namespace

--- a/Maintenance.Client/Services/UserSession.vb
+++ b/Maintenance.Client/Services/UserSession.vb
@@ -1,0 +1,20 @@
+Namespace Maintenance.Client.Services
+    Public Class UserSession
+        Private Shared _instance As UserSession
+
+        Public Property Username As String
+        Public Property Role As String
+
+        Private Sub New()
+        End Sub
+
+        Public Shared ReadOnly Property Instance As UserSession
+            Get
+                If _instance Is Nothing Then
+                    _instance = New UserSession()
+                End If
+                Return _instance
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/LoginWindow.xaml
+++ b/Maintenance.Client/Views/LoginWindow.xaml
@@ -1,0 +1,27 @@
+<Window x:Class="Maintenance.Client.Views.LoginWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Title="Login" Height="250" Width="400" WindowStartupLocation="CenterScreen">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBox x:Name="UsernameTextBox"
+                 Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                 materialDesign:HintAssist.Hint="Username"
+                 Margin="0,0,0,16" />
+        <PasswordBox x:Name="PasswordBox"
+                     Grid.Row="1"
+                     Style="{StaticResource MaterialDesignFloatingHintPasswordBox}"
+                     materialDesign:HintAssist.Hint="Password"
+                     Margin="0,0,0,24" />
+        <Button Content="Accedi"
+                Grid.Row="2"
+                Style="{StaticResource MaterialDesignRaisedButton}"
+                Width="100" HorizontalAlignment="Right"
+                Click="OnLoginClick" />
+    </Grid>
+</Window>

--- a/Maintenance.Client/Views/LoginWindow.xaml.vb
+++ b/Maintenance.Client/Views/LoginWindow.xaml.vb
@@ -1,0 +1,39 @@
+Imports System.ServiceModel
+Imports System.Windows
+Imports Maintenance.Client.Services
+
+Namespace Maintenance.Client.Views
+    Public Partial Class LoginWindow
+        Inherits Window
+
+        Private ReadOnly _factory As ChannelFactory(Of IMaintenanceService)
+
+        Public Sub New()
+            InitializeComponent()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            _factory = New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+        End Sub
+
+        Private Sub OnLoginClick(sender As Object, e As RoutedEventArgs)
+            Dim username = UsernameTextBox.Text
+            Dim password = PasswordBox.Password
+            Try
+                Dim client = _factory.CreateChannel()
+                Dim roles = client.AuthenticateUser(username, password)
+
+                Dim session = UserSession.Instance
+                session.Username = username
+                session.Role = If(roles.Any(), roles(0), String.Empty)
+
+                Dim main = New MainWindow()
+                main.Show()
+                Me.Close()
+            Catch ex As FaultException(Of String)
+                MessageBox.Show(ex.Detail, "Errore di autenticazione", MessageBoxButton.OK, MessageBoxImage.Error)
+            Catch ex As Exception
+                MessageBox.Show(ex.Message, "Errore", MessageBoxButton.OK, MessageBoxImage.Error)
+            End Try
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
## Summary
- create Material Design login window with username and password fields
- call WCF authentication service and store information in UserSession
- open MainWindow on successful login
- change `StartupUri` to show the login window first

## Testing
- `dotnet build Maintenance.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688374fc56e48327be73106b7af6cc2c