### PR TITLE
Add Dashboard view and data retrieval

### DIFF
--- a/Maintenance.Client/ViewModels/DashboardViewModel.vb
+++ b/Maintenance.Client/ViewModels/DashboardViewModel.vb
@@ -1,0 +1,74 @@
+Imports System.ServiceModel
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.DTOs
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class DashboardViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+        Private _ticketCounts As Dictionary(Of String, Integer)
+        Private _interventiNext7Days As Integer
+        Private _appointments As List(Of Pianificazione)
+
+        Public Sub New()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+            LoadData()
+        End Sub
+
+        Private Sub LoadData()
+            Try
+                Dim data = _service.GetDashboardData()
+                TicketCounts = data.TicketCounts
+                InterventiNext7Days = data.InterventiProssimi7Giorni
+                Appointments = data.UpcomingAppointments
+            Catch ex As Exception
+                ' In produzione gestire log e notifiche
+            End Try
+        End Sub
+
+        Public Property TicketCounts As Dictionary(Of String, Integer)
+            Get
+                Return _ticketCounts
+            End Get
+            Set(value As Dictionary(Of String, Integer))
+                If _ticketCounts IsNot value Then
+                    _ticketCounts = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property InterventiNext7Days As Integer
+            Get
+                Return _interventiNext7Days
+            End Get
+            Set(value As Integer)
+                If _interventiNext7Days <> value Then
+                    _interventiNext7Days = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property Appointments As List(Of Pianificazione)
+            Get
+                Return _appointments
+            End Get
+            Set(value As List(Of Pianificazione))
+                If _appointments IsNot value Then
+                    _appointments = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Sub Refresh()
+            LoadData()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/MainViewModel.vb
+++ b/Maintenance.Client/ViewModels/MainViewModel.vb
@@ -8,7 +8,7 @@ Namespace Maintenance.Client.ViewModels
 
         Public Sub New()
             Navigation = New NavigationService()
-            Navigation.Navigate(New HomeViewModel())
+            Navigation.Navigate(New DashboardViewModel())
         End Sub
     End Class
 End Namespace

--- a/Maintenance.Client/Views/DashboardView.xaml
+++ b/Maintenance.Client/Views/DashboardView.xaml
@@ -1,0 +1,51 @@
+<UserControl x:Class="Maintenance.Client.Views.DashboardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
+    <ScrollViewer>
+        <StackPanel Margin="16">
+            <WrapPanel>
+                <materialDesign:Card Width="180" Margin="4">
+                    <StackPanel>
+                        <TextBlock Text="Aperti" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TicketCounts[Aperto]}" FontSize="24" />
+                    </StackPanel>
+                </materialDesign:Card>
+                <materialDesign:Card Width="180" Margin="4">
+                    <StackPanel>
+                        <TextBlock Text="In lavorazione" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TicketCounts[InLavorazione]}" FontSize="24" />
+                    </StackPanel>
+                </materialDesign:Card>
+                <materialDesign:Card Width="180" Margin="4">
+                    <StackPanel>
+                        <TextBlock Text="Completati" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TicketCounts[Completato]}" FontSize="24" />
+                    </StackPanel>
+                </materialDesign:Card>
+                <materialDesign:Card Width="180" Margin="4">
+                    <StackPanel>
+                        <TextBlock Text="Chiusi" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TicketCounts[Chiuso]}" FontSize="24" />
+                    </StackPanel>
+                </materialDesign:Card>
+            </WrapPanel>
+
+            <materialDesign:Card Margin="0,16,0,0">
+                <StackPanel Margin="8">
+                    <TextBlock Text="Interventi prossimi 7 giorni" FontWeight="Bold" />
+                    <TextBlock Text="{Binding InterventiNext7Days}" FontSize="24" />
+                </StackPanel>
+            </materialDesign:Card>
+
+            <materialDesign:Card Margin="0,16,0,0">
+                <StackPanel Margin="8">
+                    <TextBlock Text="Prossimi appuntamenti" FontWeight="Bold" Margin="0,0,0,8" />
+                    <Calendar x:Name="AppointmentsCalendar" DisplayDate="{x:Static sys:DateTime.Now}" />
+                    <ListBox ItemsSource="{Binding Appointments}" DisplayMemberPath="Data" />
+                </StackPanel>
+            </materialDesign:Card>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Maintenance.Client/Views/DashboardView.xaml.vb
+++ b/Maintenance.Client/Views/DashboardView.xaml.vb
@@ -1,0 +1,11 @@
+Imports System.Windows.Controls
+
+Namespace Maintenance.Client.Views
+    Public Partial Class DashboardView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/MainWindow.xaml
+++ b/Maintenance.Client/Views/MainWindow.xaml
@@ -8,6 +8,9 @@
         <DataTemplate DataType="{x:Type vm:HomeViewModel}">
             <views:HomeView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:DashboardViewModel}">
+            <views:DashboardView />
+        </DataTemplate>
     </Window.Resources>
     <Grid>
         <ContentControl Content="{Binding Navigation.CurrentViewModel}" />

--- a/Maintenance.Server/Background/PianificazioneWorker.vb
+++ b/Maintenance.Server/Background/PianificazioneWorker.vb
@@ -64,7 +64,8 @@ Namespace Maintenance.Server.Background
                             .Descrizione = p.Descrizione,
                             .DataApertura = now,
                             .ClienteId = p.Carrello.ClienteId,
-                            .CarrelloId = p.CarrelloId
+                            .CarrelloId = p.CarrelloId,
+                            .Stato = TicketStatus.Aperto
                         }
                         ctx.Tickets.Add(ticket)
                         ctx.SaveChanges()

--- a/Maintenance.Shared/DTOs/DashboardData.vb
+++ b/Maintenance.Shared/DTOs/DashboardData.vb
@@ -1,0 +1,7 @@
+Namespace Maintenance.Shared.DTOs
+    Public Class DashboardData
+        Public Property TicketCounts As Dictionary(Of String, Integer)
+        Public Property InterventiProssimi7Giorni As Integer
+        Public Property UpcomingAppointments As List(Of Maintenance.Shared.Models.Pianificazione)
+    End Class
+End Namespace

--- a/Maintenance.Shared/Models/Ticket.vb
+++ b/Maintenance.Shared/Models/Ticket.vb
@@ -6,6 +6,8 @@ Namespace Maintenance.Shared.Models
         Public Property DataApertura As DateTime
         Public Property DataChiusura As DateTime?
 
+        Public Property Stato As TicketStatus
+
         Public Property ClienteId As Integer
         Public Property Cliente As Cliente
 

--- a/Maintenance.Shared/Models/TicketStatus.vb
+++ b/Maintenance.Shared/Models/TicketStatus.vb
@@ -1,0 +1,8 @@
+Namespace Maintenance.Shared.Models
+    Public Enum TicketStatus
+        Aperto
+        InLavorazione
+        Completato
+        Chiuso
+    End Enum
+End Namespace


### PR DESCRIPTION
## Summary
- implement `TicketStatus` enumeration and add `Stato` to `Ticket`
- add `DashboardData` DTO for aggregated info
- extend WCF service with `GetDashboardData`
- add dashboard cards view and view model
- set main window to display dashboard on startup
- update worker to assign initial ticket status

## Testing
- `dotnet build Maintenance.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837643b910832790c8d0f80ea93412