### PR TITLE
Implementazione vista operatori e skill

### DIFF
--- a/Maintenance.Client/Services/IMaintenanceService.vb
+++ b/Maintenance.Client/Services/IMaintenanceService.vb
@@ -29,6 +29,26 @@ Namespace Maintenance.Client.Services
         <OperationContract>
         Function GetDocumenti() As List(Of Maintenance.Shared.Models.Documento)
 
+        'Operatori
+        <OperationContract>
+        Function CreateOperatore(operatore As Maintenance.Shared.Models.Operatore) As Maintenance.Shared.Models.Operatore
+        <OperationContract>
+        Function GetOperatori() As List(Of Maintenance.Shared.Models.Operatore)
+        <OperationContract>
+        Function UpdateOperatore(operatore As Maintenance.Shared.Models.Operatore) As Maintenance.Shared.Models.Operatore
+        <OperationContract>
+        Function DeleteOperatore(id As Integer) As Boolean
+
+        'Skill
+        <OperationContract>
+        Function GetSkills() As List(Of Maintenance.Shared.Models.Skill)
+        <OperationContract>
+        Function CreateSkill(skill As Maintenance.Shared.Models.Skill) As Maintenance.Shared.Models.Skill
+        <OperationContract>
+        Function UpdateSkill(skill As Maintenance.Shared.Models.Skill) As Maintenance.Shared.Models.Skill
+        <OperationContract>
+        Function DeleteSkill(id As Integer) As Boolean
+
         'Autenticazione
         <OperationContract>
         Function AuthenticateUser(username As String, password As String) As List(Of String)

--- a/Maintenance.Client/ViewModels/OperatoriViewModel.vb
+++ b/Maintenance.Client/ViewModels/OperatoriViewModel.vb
@@ -1,0 +1,132 @@
+Imports System.Collections.ObjectModel
+Imports System.ServiceModel
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class OperatoriViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+        Private _operatori As ObservableCollection(Of Operatore)
+        Private _filtered As ObservableCollection(Of Operatore)
+        Private _searchText As String
+        Private _selected As Operatore
+        Private _skills As ObservableCollection(Of Skill)
+
+        Public Sub New()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+            LoadData()
+        End Sub
+
+        Private Sub LoadData()
+            Try
+                Dim list = _service.GetOperatori()
+                Operatori = New ObservableCollection(Of Operatore)(list)
+                Skills = New ObservableCollection(Of Skill)(_service.GetSkills())
+                ApplyFilter()
+            Catch ex As Exception
+                ' gestione errori semplificata
+            End Try
+        End Sub
+
+        Public Property Operatori As ObservableCollection(Of Operatore)
+            Get
+                Return _operatori
+            End Get
+            Set(value As ObservableCollection(Of Operatore))
+                If _operatori IsNot value Then
+                    _operatori = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property FilteredOperatori As ObservableCollection(Of Operatore)
+            Get
+                Return _filtered
+            End Get
+            Private Set(value As ObservableCollection(Of Operatore))
+                If _filtered IsNot value Then
+                    _filtered = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property SearchText As String
+            Get
+                Return _searchText
+            End Get
+            Set(value As String)
+                If _searchText <> value Then
+                    _searchText = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedOperatore As Operatore
+            Get
+                Return _selected
+            End Get
+            Set(value As Operatore)
+                If _selected IsNot value Then
+                    _selected = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property Skills As ObservableCollection(Of Skill)
+            Get
+                Return _skills
+            End Get
+            Private Set(value As ObservableCollection(Of Skill))
+                If _skills IsNot value Then
+                    _skills = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Private Sub ApplyFilter()
+            If Operatori Is Nothing Then
+                FilteredOperatori = New ObservableCollection(Of Operatore)()
+                Return
+            End If
+            Dim query = Operatori.AsEnumerable()
+            If Not String.IsNullOrWhiteSpace(SearchText) Then
+                query = query.Where(Function(o) o.Nome IsNot Nothing AndAlso o.Nome.ToLower().Contains(SearchText.ToLower()))
+            End If
+            FilteredOperatori = New ObservableCollection(Of Operatore)(query)
+        End Sub
+
+        Public Sub AddOperatore(op As Operatore)
+            Dim created = _service.CreateOperatore(op)
+            Operatori.Add(created)
+            ApplyFilter()
+        End Sub
+
+        Public Sub UpdateOperatore(op As Operatore)
+            Dim updated = _service.UpdateOperatore(op)
+            Dim idx = Operatori.IndexOf(op)
+            If idx >= 0 Then
+                Operatori(idx) = updated
+            End If
+            ApplyFilter()
+        End Sub
+
+        Public Sub DeleteSelected()
+            If SelectedOperatore Is Nothing Then Return
+            If _service.DeleteOperatore(SelectedOperatore.Id) Then
+                Operatori.Remove(SelectedOperatore)
+                ApplyFilter()
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/SkillViewModel.vb
+++ b/Maintenance.Client/ViewModels/SkillViewModel.vb
@@ -1,0 +1,74 @@
+Imports System.Collections.ObjectModel
+Imports System.ServiceModel
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class SkillViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+        Private _skills As ObservableCollection(Of Skill)
+        Private _selected As Skill
+
+        Public Sub New()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+            LoadSkills()
+        End Sub
+
+        Private Sub LoadSkills()
+            Try
+                Dim list = _service.GetSkills()
+                Skills = New ObservableCollection(Of Skill)(list)
+            Catch ex As Exception
+            End Try
+        End Sub
+
+        Public Property Skills As ObservableCollection(Of Skill)
+            Get
+                Return _skills
+            End Get
+            Private Set(value As ObservableCollection(Of Skill))
+                If _skills IsNot value Then
+                    _skills = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedSkill As Skill
+            Get
+                Return _selected
+            End Get
+            Set(value As Skill)
+                If _selected IsNot value Then
+                    _selected = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Sub AddSkill(skill As Skill)
+            Dim created = _service.CreateSkill(skill)
+            Skills.Add(created)
+        End Sub
+
+        Public Sub UpdateSkill(skill As Skill)
+            Dim updated = _service.UpdateSkill(skill)
+            Dim idx = Skills.IndexOf(skill)
+            If idx >= 0 Then
+                Skills(idx) = updated
+            End If
+        End Sub
+
+        Public Sub DeleteSelected()
+            If SelectedSkill Is Nothing Then Return
+            If _service.DeleteSkill(SelectedSkill.Id) Then
+                Skills.Remove(SelectedSkill)
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/MainWindow.xaml
+++ b/Maintenance.Client/Views/MainWindow.xaml
@@ -17,6 +17,12 @@
         <DataTemplate DataType="{x:Type vm:CarrelliViewModel}">
             <views:CarrelliView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:OperatoriViewModel}">
+            <views:OperatoriView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SkillViewModel}">
+            <views:SkillView />
+        </DataTemplate>
     </Window.Resources>
     <Grid>
         <ContentControl Content="{Binding Navigation.CurrentViewModel}" />

--- a/Maintenance.Client/Views/OperatoreDetailDialog.xaml
+++ b/Maintenance.Client/Views/OperatoreDetailDialog.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Maintenance.Client.Views.OperatoreDetailDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="16">
+        <TextBlock Text="Nome" />
+        <TextBox x:Name="NameBox" Width="200" Margin="0,0,0,8" Text="{Binding Operatore.Nome, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Text="Skill" />
+        <ListBox x:Name="SkillsList" ItemsSource="{Binding Skills}" DisplayMemberPath="Nome" SelectionMode="Multiple" Height="150" Margin="0,0,0,8" />
+        <Button Content="Salva" Width="80" HorizontalAlignment="Right" Click="OnSave" />
+    </StackPanel>
+</UserControl>

--- a/Maintenance.Client/Views/OperatoreDetailDialog.xaml.vb
+++ b/Maintenance.Client/Views/OperatoreDetailDialog.xaml.vb
@@ -1,0 +1,37 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class OperatoreDetailDialog
+        Inherits UserControl
+
+        Public Event Saved()
+
+        Public Property Operatore As Operatore
+        Public Property Skills As List(Of Skill)
+
+        Public Sub New(model As Operatore, available As IEnumerable(Of Skill))
+            InitializeComponent()
+            Operatore = model
+            Skills = available.ToList()
+            DataContext = Me
+            If Operatore.OperatoreSkills IsNot Nothing Then
+                For Each os In Operatore.OperatoreSkills
+                    Dim skill = Skills.FirstOrDefault(Function(s) s.Id = os.SkillId)
+                    If skill IsNot Nothing Then
+                        SkillsList.SelectedItems.Add(skill)
+                    End If
+                Next
+            End If
+        End Sub
+
+        Private Sub OnSave(sender As Object, e As RoutedEventArgs)
+            Operatore.OperatoreSkills = New List(Of OperatoreSkill)()
+            For Each s As Skill In SkillsList.SelectedItems
+                Operatore.OperatoreSkills.Add(New OperatoreSkill With {.OperatoreId = Operatore.Id, .SkillId = s.Id})
+            Next
+            RaiseEvent Saved()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/OperatoriView.xaml
+++ b/Maintenance.Client/Views/OperatoriView.xaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="Maintenance.Client.Views.OperatoriView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
+    <materialDesign:DialogHost x:Name="Host">
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBox Width="200" Margin="0,0,8,0" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Cerca" />
+                <Button Content="Nuovo" Margin="0,0,8,0" Click="OnAdd" />
+                <Button Content="Modifica" Margin="0,0,8,0" Click="OnEdit" />
+                <Button Content="Elimina" Click="OnDelete" />
+            </StackPanel>
+            <DataGrid Grid.Row="1" AutoGenerateColumns="False" ItemsSource="{Binding FilteredOperatori}" SelectedItem="{Binding SelectedOperatore}" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Nome" Binding="{Binding Nome}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+    </materialDesign:DialogHost>
+</UserControl>

--- a/Maintenance.Client/Views/OperatoriView.xaml.vb
+++ b/Maintenance.Client/Views/OperatoriView.xaml.vb
@@ -1,0 +1,52 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports MaterialDesignThemes.Wpf
+Imports Maintenance.Client.ViewModels
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class OperatoriView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+
+        Private ReadOnly Property Vm As OperatoriViewModel
+            Get
+                Return TryCast(DataContext, OperatoriViewModel)
+            End Get
+        End Property
+
+        Private Sub OnAdd(sender As Object, e As RoutedEventArgs)
+            Dim nuovo As New Operatore()
+            ShowDialog(nuovo, Sub()
+                                   Vm.AddOperatore(nuovo)
+                               End Sub)
+        End Sub
+
+        Private Sub OnEdit(sender As Object, e As RoutedEventArgs)
+            If Vm.SelectedOperatore Is Nothing Then Return
+            Dim clone As New Operatore() With {.Id = Vm.SelectedOperatore.Id, .Nome = Vm.SelectedOperatore.Nome}
+            clone.OperatoreSkills = Vm.SelectedOperatore.OperatoreSkills?.Select(Function(os) New OperatoreSkill With {.OperatoreId = os.OperatoreId, .SkillId = os.SkillId}).ToList()
+            ShowDialog(clone, Sub()
+                                   Vm.SelectedOperatore.Nome = clone.Nome
+                                   Vm.SelectedOperatore.OperatoreSkills = clone.OperatoreSkills
+                                   Vm.UpdateOperatore(Vm.SelectedOperatore)
+                               End Sub)
+        End Sub
+
+        Private Sub OnDelete(sender As Object, e As RoutedEventArgs)
+            Vm.DeleteSelected()
+        End Sub
+
+        Private Sub ShowDialog(model As Operatore, onSave As Action)
+            Dim dialog As New OperatoreDetailDialog(model, Vm.Skills)
+            AddHandler dialog.Saved, Sub()
+                                          onSave()
+                                          DialogHost.CloseDialogCommand.Execute(Nothing, Host)
+                                      End Sub
+            DialogHost.Show(dialog, "Host")
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/SkillView.xaml
+++ b/Maintenance.Client/Views/SkillView.xaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="Maintenance.Client.Views.SkillView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
+    <materialDesign:DialogHost x:Name="Host">
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <Button Content="Nuovo" Margin="0,0,8,0" Click="OnAdd" />
+                <Button Content="Modifica" Margin="0,0,8,0" Click="OnEdit" />
+                <Button Content="Elimina" Click="OnDelete" />
+            </StackPanel>
+            <DataGrid Grid.Row="1" AutoGenerateColumns="False" ItemsSource="{Binding Skills}" SelectedItem="{Binding SelectedSkill}" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Nome" Binding="{Binding Nome}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+    </materialDesign:DialogHost>
+</UserControl>

--- a/Maintenance.Client/Views/SkillView.xaml.vb
+++ b/Maintenance.Client/Views/SkillView.xaml.vb
@@ -1,0 +1,57 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Data
+Imports MaterialDesignThemes.Wpf
+Imports Maintenance.Client.ViewModels
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class SkillView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+
+        Private ReadOnly Property Vm As SkillViewModel
+            Get
+                Return TryCast(DataContext, SkillViewModel)
+            End Get
+        End Property
+
+        Private Sub OnAdd(sender As Object, e As RoutedEventArgs)
+            Dim nuovo As New Skill()
+            ShowDialog(nuovo, Sub()
+                                   Vm.AddSkill(nuovo)
+                               End Sub)
+        End Sub
+
+        Private Sub OnEdit(sender As Object, e As RoutedEventArgs)
+            If Vm.SelectedSkill Is Nothing Then Return
+            Dim clone As New Skill() With {.Id = Vm.SelectedSkill.Id, .Nome = Vm.SelectedSkill.Nome}
+            ShowDialog(clone, Sub()
+                                   Vm.SelectedSkill.Nome = clone.Nome
+                                   Vm.UpdateSkill(Vm.SelectedSkill)
+                               End Sub)
+        End Sub
+
+        Private Sub OnDelete(sender As Object, e As RoutedEventArgs)
+            Vm.DeleteSelected()
+        End Sub
+
+        Private Sub ShowDialog(model As Skill, onSave As Action)
+            Dim panel As New StackPanel()
+            panel.Children.Add(New TextBlock() With {.Text = "Nome"})
+            Dim nameBox As New TextBox() With {.Width = 200, .Margin = New Thickness(0,0,0,8)}
+            nameBox.SetBinding(TextBox.TextProperty, New Binding("Nome") With {.Source = model, .UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged})
+            panel.Children.Add(nameBox)
+            Dim btn As New Button() With {.Content = "Salva", .Margin = New Thickness(0,8,0,0)}
+            AddHandler btn.Click, Sub()
+                                       onSave()
+                                       DialogHost.CloseDialogCommand.Execute(Nothing, Host)
+                                   End Sub
+            panel.Children.Add(btn)
+            DialogHost.Show(panel, "Host")
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
## Summary
- expose Operatore e Skill nel servizio client
- aggiunge DataTemplate per OperatoriViewModel e SkillViewModel
- implementa OperatoriViewModel e SkillViewModel
- crea dialog per dettaglio operatore con multi selezione skill
- aggiunge viste OperatoriView e SkillView

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Maintenance.sln -c Release` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_68837d3694f083279c35497ab056c1fe