### PR TITLE
Implement Ticket list and detail views

### DIFF
--- a/Maintenance.Client/Services/IMaintenanceService.vb
+++ b/Maintenance.Client/Services/IMaintenanceService.vb
@@ -29,6 +29,22 @@ Namespace Maintenance.Client.Services
         <OperationContract>
         Function GetDocumenti() As List(Of Maintenance.Shared.Models.Documento)
 
+        'Ticket
+        <OperationContract>
+        Function GetTickets() As List(Of Maintenance.Shared.Models.Ticket)
+        <OperationContract>
+        Function CreateTicket(ticket As Maintenance.Shared.Models.Ticket) As Maintenance.Shared.Models.Ticket
+        <OperationContract>
+        Function UpdateTicket(ticket As Maintenance.Shared.Models.Ticket) As Maintenance.Shared.Models.Ticket
+        <OperationContract>
+        Function DeleteTicket(id As Integer) As Boolean
+
+        'Allegati ticket
+        <OperationContract>
+        Function CreateAllegatoTicket(allegato As Maintenance.Shared.Models.AllegatoTicket) As Maintenance.Shared.Models.AllegatoTicket
+        <OperationContract>
+        Function DeleteAllegatoTicket(id As Integer) As Boolean
+
         'Operatori
         <OperationContract>
         Function CreateOperatore(operatore As Maintenance.Shared.Models.Operatore) As Maintenance.Shared.Models.Operatore

--- a/Maintenance.Client/ViewModels/TicketListViewModel.vb
+++ b/Maintenance.Client/ViewModels/TicketListViewModel.vb
@@ -1,0 +1,230 @@
+Imports System.Collections.ObjectModel
+Imports System.ServiceModel
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class TicketListViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+        Private _tickets As ObservableCollection(Of Ticket)
+        Private _filtered As ObservableCollection(Of Ticket)
+        Private _operatori As ObservableCollection(Of Operatore)
+        Private _clienti As ObservableCollection(Of Cliente)
+        Private _carrelli As ObservableCollection(Of Carrello)
+
+        Private _selectedStato As TicketStatus?
+        Private _selectedPriorita As String
+        Private _selectedTecnico As Operatore
+        Private _dataDa As Date?
+        Private _dataA As Date?
+        Private _selected As Ticket
+
+        Public ReadOnly Property Statuses As Array = [Enum].GetValues(GetType(TicketStatus))
+        Public ReadOnly Property PrioritaOptions As String() = {"Bassa", "Media", "Alta"}
+
+        Public Sub New()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+            LoadData()
+        End Sub
+
+        Private Sub LoadData()
+            Try
+                Tickets = New ObservableCollection(Of Ticket)(_service.GetTickets())
+                Operatori = New ObservableCollection(Of Operatore)(_service.GetOperatori())
+                Clienti = New ObservableCollection(Of Cliente)(_service.GetClienti())
+                Carrelli = New ObservableCollection(Of Carrello)(_service.GetCarrelli())
+                ApplyFilter()
+            Catch ex As Exception
+            End Try
+        End Sub
+
+        Public Property Tickets As ObservableCollection(Of Ticket)
+            Get
+                Return _tickets
+            End Get
+            Set(value As ObservableCollection(Of Ticket))
+                If _tickets IsNot value Then
+                    _tickets = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property FilteredTickets As ObservableCollection(Of Ticket)
+            Get
+                Return _filtered
+            End Get
+            Private Set(value As ObservableCollection(Of Ticket))
+                If _filtered IsNot value Then
+                    _filtered = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property Operatori As ObservableCollection(Of Operatore)
+            Get
+                Return _operatori
+            End Get
+            Private Set(value As ObservableCollection(Of Operatore))
+                If _operatori IsNot value Then
+                    _operatori = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property Clienti As ObservableCollection(Of Cliente)
+            Get
+                Return _clienti
+            End Get
+            Private Set(value As ObservableCollection(Of Cliente))
+                If _clienti IsNot value Then
+                    _clienti = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property Carrelli As ObservableCollection(Of Carrello)
+            Get
+                Return _carrelli
+            End Get
+            Private Set(value As ObservableCollection(Of Carrello))
+                If _carrelli IsNot value Then
+                    _carrelli = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedStato As TicketStatus?
+            Get
+                Return _selectedStato
+            End Get
+            Set(value As TicketStatus?)
+                If _selectedStato <> value Then
+                    _selectedStato = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedPriorita As String
+            Get
+                Return _selectedPriorita
+            End Get
+            Set(value As String)
+                If _selectedPriorita <> value Then
+                    _selectedPriorita = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedTecnico As Operatore
+            Get
+                Return _selectedTecnico
+            End Get
+            Set(value As Operatore)
+                If _selectedTecnico IsNot value Then
+                    _selectedTecnico = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property DataDa As Date?
+            Get
+                Return _dataDa
+            End Get
+            Set(value As Date?)
+                If _dataDa <> value Then
+                    _dataDa = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property DataA As Date?
+            Get
+                Return _dataA
+            End Get
+            Set(value As Date?)
+                If _dataA <> value Then
+                    _dataA = value
+                    OnPropertyChanged()
+                    ApplyFilter()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedTicket As Ticket
+            Get
+                Return _selected
+            End Get
+            Set(value As Ticket)
+                If _selected IsNot value Then
+                    _selected = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Private Sub ApplyFilter()
+            If Tickets Is Nothing Then
+                FilteredTickets = New ObservableCollection(Of Ticket)()
+                Return
+            End If
+            Dim query = Tickets.AsEnumerable()
+            If SelectedStato.HasValue Then
+                query = query.Where(Function(t) t.Stato = SelectedStato.Value)
+            End If
+            If Not String.IsNullOrWhiteSpace(SelectedPriorita) Then
+                query = query.Where(Function(t) t.Priorita = SelectedPriorita)
+            End If
+            If SelectedTecnico IsNot Nothing Then
+                query = query.Where(Function(t) t.TecnicoId = SelectedTecnico.Id)
+            End If
+            If DataDa.HasValue Then
+                query = query.Where(Function(t) t.DataRichiesta >= DataDa.Value)
+            End If
+            If DataA.HasValue Then
+                query = query.Where(Function(t) t.DataRichiesta <= DataA.Value)
+            End If
+            FilteredTickets = New ObservableCollection(Of Ticket)(query)
+        End Sub
+
+        Public Sub AddTicket(ticket As Ticket)
+            Dim created = _service.CreateTicket(ticket)
+            Tickets.Add(created)
+            ApplyFilter()
+        End Sub
+
+        Public Sub UpdateTicket(ticket As Ticket)
+            Dim updated = _service.UpdateTicket(ticket)
+            Dim idx = Tickets.IndexOf(ticket)
+            If idx >= 0 Then
+                Tickets(idx) = updated
+            End If
+            ApplyFilter()
+        End Sub
+
+        Public Sub DeleteSelected()
+            If SelectedTicket Is Nothing Then Return
+            If _service.DeleteTicket(SelectedTicket.Id) Then
+                Tickets.Remove(SelectedTicket)
+                ApplyFilter()
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/TicketDetailDialog.xaml
+++ b/Maintenance.Client/Views/TicketDetailDialog.xaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="Maintenance.Client.Views.TicketDetailDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/wpf/2008/toolkit">
+    <ScrollViewer>
+        <StackPanel Margin="16">
+            <TextBlock Text="Numero" />
+            <TextBox Width="200" Margin="0,0,0,8" Text="{Binding Ticket.Numero, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBlock Text="Cliente" />
+            <toolkit:AutoCompleteBox x:Name="ClienteBox" Width="200" Margin="0,0,0,8"
+                                     ItemsSource="{Binding Clienti}" DisplayMemberPath="Nome" SelectedItem="{Binding SelectedCliente}" />
+            <TextBlock Text="Carrello" />
+            <toolkit:AutoCompleteBox x:Name="CarrelloBox" Width="200" Margin="0,0,0,8"
+                                     ItemsSource="{Binding Carrelli}" DisplayMemberPath="NumeroSerie" SelectedItem="{Binding SelectedCarrello}" />
+            <TextBlock Text="Tipo" />
+            <ComboBox Width="200" Margin="0,0,0,8" ItemsSource="{Binding TipoOptions}" SelectedItem="{Binding Ticket.Tipo}" />
+            <TextBlock Text="Priorità" />
+            <ComboBox Width="200" Margin="0,0,0,8" ItemsSource="{Binding PrioritaOptions}" SelectedItem="{Binding Ticket.Priorita}" />
+            <TextBlock Text="Data richiesta" />
+            <DatePicker Width="200" Margin="0,0,0,8" SelectedDate="{Binding Ticket.DataRichiesta}" />
+            <TextBlock Text="Descrizione" />
+            <TextBox Text="{Binding Ticket.Descrizione}" AcceptsReturn="True" Height="80" Margin="0,0,0,8" />
+            <Button Content="Aggiungi allegato" Width="120" Margin="0,0,0,8" Click="OnAddAttachment" />
+            <ListBox ItemsSource="{Binding Allegati}" SelectedItem="{Binding SelectedAllegato}" Height="80">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding NomeFile}" Width="150" />
+                            <Button Content="Elimina" Margin="8,0,0,0" CommandParameter="{Binding}" Click="OnRemoveAttachment" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <Button Content="Salva" Width="80" HorizontalAlignment="Right" Margin="0,8,0,0" Click="OnSave" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Maintenance.Client/Views/TicketDetailDialog.xaml.vb
+++ b/Maintenance.Client/Views/TicketDetailDialog.xaml.vb
@@ -1,0 +1,71 @@
+Imports System.Collections.ObjectModel
+Imports System.IO
+Imports System.Windows
+Imports System.Windows.Controls
+Imports Microsoft.Win32
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class TicketDetailDialog
+        Inherits UserControl
+
+        Public Event Saved()
+
+        Public Property Ticket As Ticket
+        Public Property Clienti As List(Of Cliente)
+        Public Property Carrelli As List(Of Carrello)
+        Public Property TipoOptions As List(Of String)
+        Public Property PrioritaOptions As List(Of String)
+        Public Property Allegati As ObservableCollection(Of AllegatoTicket)
+        Public Property SelectedCliente As Cliente
+        Public Property SelectedCarrello As Carrello
+        Public Property SelectedAllegato As AllegatoTicket
+
+        Public Sub New(model As Ticket, cls As IEnumerable(Of Cliente), cars As IEnumerable(Of Carrello))
+            InitializeComponent()
+            Ticket = model
+            Clienti = cls.ToList()
+            Carrelli = cars.ToList()
+            TipoOptions = New List(Of String)({"Guasto", "Manutenzione"})
+            PrioritaOptions = New List(Of String)({"Bassa", "Media", "Alta"})
+            If Ticket.Allegati IsNot Nothing Then
+                Allegati = New ObservableCollection(Of AllegatoTicket)(Ticket.Allegati)
+            Else
+                Allegati = New ObservableCollection(Of AllegatoTicket)()
+            End If
+            DataContext = Me
+            If Ticket.Cliente IsNot Nothing Then SelectedCliente = Ticket.Cliente
+            If Ticket.Carrello IsNot Nothing Then SelectedCarrello = Ticket.Carrello
+        End Sub
+
+        Private Sub OnAddAttachment(sender As Object, e As RoutedEventArgs)
+            Dim dlg As New OpenFileDialog() With {.Filter = "Files|*.png;*.jpg;*.jpeg;*.pdf", .Multiselect = True}
+            If dlg.ShowDialog() Then
+                For Each f In dlg.FileNames
+                    Dim a As New AllegatoTicket With {
+                        .NomeFile = System.IO.Path.GetFileName(f),
+                        .Contenuto = File.ReadAllBytes(f)
+                    }
+                    Allegati.Add(a)
+                Next
+            End If
+        End Sub
+
+        Private Sub OnRemoveAttachment(sender As Object, e As RoutedEventArgs)
+            Dim btn = TryCast(sender, Button)
+            Dim item = TryCast(btn?.CommandParameter, AllegatoTicket)
+            If item IsNot Nothing Then
+                Allegati.Remove(item)
+            End If
+        End Sub
+
+        Private Sub OnSave(sender As Object, e As RoutedEventArgs)
+            Ticket.Cliente = SelectedCliente
+            If SelectedCliente IsNot Nothing Then Ticket.ClienteId = SelectedCliente.Id
+            Ticket.Carrello = SelectedCarrello
+            If SelectedCarrello IsNot Nothing Then Ticket.CarrelloId = SelectedCarrello.Id
+            Ticket.Allegati = Allegati.ToList()
+            RaiseEvent Saved()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/TicketListView.xaml
+++ b/Maintenance.Client/Views/TicketListView.xaml
@@ -1,0 +1,35 @@
+<UserControl x:Class="Maintenance.Client.Views.TicketListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
+    <materialDesign:DialogHost x:Name="Host">
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <ComboBox Width="120" Margin="0,0,8,0" ItemsSource="{Binding Statuses}" SelectedItem="{Binding SelectedStato}" />
+                <ComboBox Width="120" Margin="0,0,8,0" ItemsSource="{Binding PrioritaOptions}" SelectedItem="{Binding SelectedPriorita}" />
+                <DatePicker Width="120" Margin="0,0,8,0" SelectedDate="{Binding DataDa}" />
+                <DatePicker Width="120" Margin="0,0,8,0" SelectedDate="{Binding DataA}" />
+                <ComboBox Width="150" Margin="0,0,8,0" ItemsSource="{Binding Operatori}" DisplayMemberPath="Nome" SelectedItem="{Binding SelectedTecnico}" />
+                <Button Content="Nuovo" Margin="0,0,8,0" Click="OnAdd" />
+                <Button Content="Modifica" Margin="0,0,8,0" Click="OnEdit" />
+                <Button Content="Elimina" Click="OnDelete" />
+            </StackPanel>
+            <DataGrid Grid.Row="1" AutoGenerateColumns="False" ItemsSource="{Binding FilteredTickets}" SelectedItem="{Binding SelectedTicket}" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Numero" Binding="{Binding Numero}" />
+                    <DataGridTextColumn Header="Cliente" Binding="{Binding Cliente.Nome}" />
+                    <DataGridTextColumn Header="Carrello" Binding="{Binding Carrello.NumeroSerie}" />
+                    <DataGridTextColumn Header="Tipo" Binding="{Binding Tipo}" />
+                    <DataGridTextColumn Header="Priorità" Binding="{Binding Priorita}" />
+                    <DataGridTextColumn Header="Stato" Binding="{Binding Stato}" />
+                    <DataGridTextColumn Header="Tecnico" Binding="{Binding TecnicoAssegnato.Nome}" />
+                    <DataGridTextColumn Header="Data richiesta" Binding="{Binding DataRichiesta, StringFormat=d}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+    </materialDesign:DialogHost>
+</UserControl>

--- a/Maintenance.Client/Views/TicketListView.xaml.vb
+++ b/Maintenance.Client/Views/TicketListView.xaml.vb
@@ -1,0 +1,74 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Data
+Imports MaterialDesignThemes.Wpf
+Imports Maintenance.Client.ViewModels
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class TicketListView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+
+        Private ReadOnly Property Vm As TicketListViewModel
+            Get
+                Return TryCast(DataContext, TicketListViewModel)
+            End Get
+        End Property
+
+        Private Sub OnAdd(sender As Object, e As RoutedEventArgs)
+            Dim nuovo As New Ticket() With {.DataRichiesta = Date.Now, .Stato = TicketStatus.Aperto}
+            ShowDialog(nuovo, Sub() Vm.AddTicket(nuovo))
+        End Sub
+
+        Private Sub OnEdit(sender As Object, e As RoutedEventArgs)
+            If Vm.SelectedTicket Is Nothing Then Return
+            Dim clone As New Ticket With {
+                .Id = Vm.SelectedTicket.Id,
+                .Numero = Vm.SelectedTicket.Numero,
+                .Titolo = Vm.SelectedTicket.Titolo,
+                .Descrizione = Vm.SelectedTicket.Descrizione,
+                .Tipo = Vm.SelectedTicket.Tipo,
+                .Priorita = Vm.SelectedTicket.Priorita,
+                .DataRichiesta = Vm.SelectedTicket.DataRichiesta,
+                .DataApertura = Vm.SelectedTicket.DataApertura,
+                .DataChiusura = Vm.SelectedTicket.DataChiusura,
+                .Stato = Vm.SelectedTicket.Stato,
+                .ClienteId = Vm.SelectedTicket.ClienteId,
+                .CarrelloId = Vm.SelectedTicket.CarrelloId,
+                .TecnicoId = Vm.SelectedTicket.TecnicoId,
+                .Allegati = If(Vm.SelectedTicket.Allegati?.ToList(), New List(Of AllegatoTicket))
+            }
+            ShowDialog(clone, Sub()
+                                   Vm.SelectedTicket.Numero = clone.Numero
+                                   Vm.SelectedTicket.Titolo = clone.Titolo
+                                   Vm.SelectedTicket.Descrizione = clone.Descrizione
+                                   Vm.SelectedTicket.Tipo = clone.Tipo
+                                   Vm.SelectedTicket.Priorita = clone.Priorita
+                                   Vm.SelectedTicket.DataRichiesta = clone.DataRichiesta
+                                   Vm.SelectedTicket.Stato = clone.Stato
+                                   Vm.SelectedTicket.ClienteId = clone.ClienteId
+                                   Vm.SelectedTicket.CarrelloId = clone.CarrelloId
+                                   Vm.SelectedTicket.TecnicoId = clone.TecnicoId
+                                   Vm.SelectedTicket.Allegati = clone.Allegati
+                                   Vm.UpdateTicket(Vm.SelectedTicket)
+                               End Sub)
+        End Sub
+
+        Private Sub OnDelete(sender As Object, e As RoutedEventArgs)
+            Vm.DeleteSelected()
+        End Sub
+
+        Private Sub ShowDialog(model As Ticket, onSave As Action)
+            Dim dlg As New TicketDetailDialog(model, Vm.Clienti, Vm.Carrelli)
+            AddHandler dlg.Saved, Sub()
+                                       onSave()
+                                       DialogHost.CloseDialogCommand.Execute(Nothing, Host)
+                                   End Sub
+            DialogHost.Show(dlg, "Host")
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Server/Data/MaintenanceDbContext.vb
+++ b/Maintenance.Server/Data/MaintenanceDbContext.vb
@@ -87,6 +87,10 @@ Namespace Maintenance.Server.Data
             ' Ticket
             modelBuilder.Entity(Of Ticket)().HasKey(Function(t) t.Id)
             modelBuilder.Entity(Of Ticket)().Property(Function(t) t.Titolo).IsRequired()
+            modelBuilder.Entity(Of Ticket)().Property(Function(t) t.Numero).IsRequired(False)
+            modelBuilder.Entity(Of Ticket)().Property(Function(t) t.Tipo).IsRequired(False)
+            modelBuilder.Entity(Of Ticket)().Property(Function(t) t.Priorita).IsRequired(False)
+            modelBuilder.Entity(Of Ticket)().Property(Function(t) t.DataRichiesta).IsRequired()
             modelBuilder.Entity(Of Ticket)() _
                 .HasOne(Function(t) t.Cliente) _
                 .WithMany(Function(c) c.Tickets) _
@@ -95,6 +99,11 @@ Namespace Maintenance.Server.Data
                 .HasOne(Function(t) t.Carrello) _
                 .WithMany(Function(c) c.Tickets) _
                 .HasForeignKey(Function(t) t.CarrelloId) _
+                .IsRequired(False)
+            modelBuilder.Entity(Of Ticket)() _
+                .HasOne(Function(t) t.TecnicoAssegnato) _
+                .WithMany() _
+                .HasForeignKey(Function(t) t.TecnicoId) _
                 .IsRequired(False)
 
             ' AllegatoTicket

--- a/Maintenance.Shared/Models/AllegatoTicket.vb
+++ b/Maintenance.Shared/Models/AllegatoTicket.vb
@@ -3,6 +3,8 @@ Namespace Maintenance.Shared.Models
         Public Property Id As Integer
         Public Property NomeFile As String
         Public Property Percorso As String
+        'contenuto del file per memorizzazione in DB
+        Public Property Contenuto As Byte()
 
         Public Property TicketId As Integer
         Public Property Ticket As Ticket

--- a/Maintenance.Shared/Models/Ticket.vb
+++ b/Maintenance.Shared/Models/Ticket.vb
@@ -1,12 +1,20 @@
 Namespace Maintenance.Shared.Models
     Public Class Ticket
         Public Property Id As Integer
+        'numero progressivo del ticket
+        Public Property Numero As String
         Public Property Titolo As String
         Public Property Descrizione As String
+        Public Property Tipo As String
+        Public Property Priorita As String
+        Public Property DataRichiesta As DateTime
         Public Property DataApertura As DateTime
         Public Property DataChiusura As DateTime?
 
         Public Property Stato As TicketStatus
+
+        Public Property TecnicoId As Integer?
+        Public Property TecnicoAssegnato As Operatore
 
         Public Property ClienteId As Integer
         Public Property Cliente As Cliente


### PR DESCRIPTION
## Summary
- extend Ticket and AllegatoTicket models for additional data
- wire up IMaintenanceService with ticket operations
- map new Ticket fields in database context
- add TicketListView and TicketDetailDialog UI
- implement TicketListViewModel to manage filtering and CRUD

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68837ed605d88327b0c9bf864c8730f7