### PR TITLE
Add intervention list and form views

### DIFF
--- a/Maintenance.Client/ViewModels/InterventiListViewModel.vb
+++ b/Maintenance.Client/ViewModels/InterventiListViewModel.vb
@@ -1,0 +1,55 @@
+Imports System.Collections.ObjectModel
+Imports System.ServiceModel
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class InterventiListViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+        Private _interventi As ObservableCollection(Of Intervento)
+        Private _selected As Intervento
+
+        Public Sub New()
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+            LoadData()
+        End Sub
+
+        Private Sub LoadData()
+            Try
+                Dim list = _service.GetInterventi()
+                Dim filtered = list.Where(Function(i) i.Ticket IsNot Nothing AndAlso i.Ticket.Stato = TicketStatus.InLavorazione)
+                Interventi = New ObservableCollection(Of Intervento)(filtered)
+            Catch ex As Exception
+            End Try
+        End Sub
+
+        Public Property Interventi As ObservableCollection(Of Intervento)
+            Get
+                Return _interventi
+            End Get
+            Private Set(value As ObservableCollection(Of Intervento))
+                If _interventi IsNot value Then
+                    _interventi = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+
+        Public Property SelectedIntervento As Intervento
+            Get
+                Return _selected
+            End Get
+            Set(value As Intervento)
+                If _selected IsNot value Then
+                    _selected = value
+                    OnPropertyChanged()
+                End If
+            End Set
+        End Property
+    End Class
+End Namespace

--- a/Maintenance.Client/ViewModels/InterventoFormViewModel.vb
+++ b/Maintenance.Client/ViewModels/InterventoFormViewModel.vb
@@ -1,0 +1,53 @@
+Imports System.Collections.ObjectModel
+Imports System.ServiceModel
+Imports Maintenance.Client.Commands
+Imports Maintenance.Client.Services
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.ViewModels
+    Public Class InterventoFormViewModel
+        Inherits BaseViewModel
+
+        Private ReadOnly _service As IMaintenanceService
+
+        Public Property Intervento As Intervento
+        Public Property Checks As ObservableCollection(Of InterventoCheck)
+        Public Property Ricambi As ObservableCollection(Of InterventoRicambi)
+        Public Property Manodopera As ObservableCollection(Of InterventoManodopera)
+        Public ReadOnly Property EsitoOptions As List(Of String) = New List(Of String) From {"OK", "Da sostituire", "Da monitorare"}
+
+        Public ReadOnly Property SaveCommand As RelayCommand
+        Public ReadOnly Property ConcludeCommand As RelayCommand
+
+        Public Sub New(model As Intervento)
+            Intervento = model
+            Dim binding As New NetTcpBinding()
+            Dim endpoint As New EndpointAddress("net.tcp://localhost:9000/MaintenanceService")
+            Dim factory As New ChannelFactory(Of IMaintenanceService)(binding, endpoint)
+            _service = factory.CreateChannel()
+
+            Checks = New ObservableCollection(Of InterventoCheck)()
+            Ricambi = New ObservableCollection(Of InterventoRicambi)()
+            Manodopera = New ObservableCollection(Of InterventoManodopera)()
+
+            SaveCommand = New RelayCommand(Sub() SaveDraft(), Function(o) True)
+            ConcludeCommand = New RelayCommand(Sub() Complete(), Function(o) True)
+        End Sub
+
+        Private Sub SaveDraft()
+            If Intervento.Id = 0 Then
+                _service.CreateIntervento(Intervento)
+            Else
+                _service.UpdateIntervento(Intervento)
+            End If
+        End Sub
+
+        Public Sub Complete(Optional firmaTecnico As String = Nothing, Optional firmaCliente As String = Nothing)
+            SaveDraft()
+            If Not String.IsNullOrEmpty(firmaTecnico) OrElse Not String.IsNullOrEmpty(firmaCliente) Then
+                _service.SalvaFirmeIntervento(Intervento.Id, firmaTecnico, firmaCliente)
+            End If
+            _service.GeneraFoglioIntervento(Intervento.Id)
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/InterventiListView.xaml
+++ b/Maintenance.Client/Views/InterventiListView.xaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="Maintenance.Client.Views.InterventiListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
+    <materialDesign:DialogHost x:Name="Host">
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <Button Content="Apri" Margin="0,0,8,0" Click="OnOpen" />
+            </StackPanel>
+            <DataGrid Grid.Row="1" AutoGenerateColumns="False" ItemsSource="{Binding Interventi}" SelectedItem="{Binding SelectedIntervento}" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Data" Binding="{Binding DataInizio, StringFormat=g}" />
+                    <DataGridTextColumn Header="Ticket" Binding="{Binding Ticket.Numero}" />
+                    <DataGridTextColumn Header="Cliente" Binding="{Binding Ticket.Cliente.Nome}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+    </materialDesign:DialogHost>
+</UserControl>

--- a/Maintenance.Client/Views/InterventiListView.xaml.vb
+++ b/Maintenance.Client/Views/InterventiListView.xaml.vb
@@ -1,0 +1,31 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports Maintenance.Client.ViewModels
+Imports MaterialDesignThemes.Wpf
+
+Namespace Maintenance.Client.Views
+    Public Partial Class InterventiListView
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+
+        Private ReadOnly Property Vm As InterventiListViewModel
+            Get
+                Return TryCast(DataContext, InterventiListViewModel)
+            End Get
+        End Property
+
+        Private Sub OnOpen(sender As Object, e As RoutedEventArgs)
+            If Vm.SelectedIntervento Is Nothing Then Return
+            Dim dlg As New Window With {
+                .Title = "Intervento",
+                .Content = New InterventoFormView(Vm.SelectedIntervento),
+                .SizeToContent = SizeToContent.WidthAndHeight,
+                .WindowStartupLocation = WindowStartupLocation.CenterOwner
+            }
+            dlg.ShowDialog()
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/InterventoFormView.xaml
+++ b/Maintenance.Client/Views/InterventoFormView.xaml
@@ -1,0 +1,62 @@
+<UserControl x:Class="Maintenance.Client.Views.InterventoFormView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/wpf/2008/toolkit">
+    <ScrollViewer>
+        <StackPanel Margin="16">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBlock Text="Inizio" Margin="0,0,8,0" VerticalAlignment="Center" />
+                <DatePicker Width="140" SelectedDate="{Binding Intervento.DataInizio}" />
+                <TextBox Width="80" Text="{Binding Intervento.DataInizio, StringFormat=HH:mm}" Margin="8,0,0,0" />
+                <TextBlock Text="Fine" Margin="16,0,8,0" VerticalAlignment="Center" />
+                <DatePicker Width="140" SelectedDate="{Binding Intervento.DataFine}" />
+                <TextBox Width="80" Text="{Binding Intervento.DataFine, StringFormat=HH:mm}" Margin="8,0,0,0" />
+            </StackPanel>
+            <TextBlock Text="Check list" FontWeight="Bold" />
+            <ItemsControl ItemsSource="{Binding Checks}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="{Binding CheckItem.Descrizione}" Width="150" />
+                            <ComboBox Width="120" ItemsSource="{Binding DataContext.EsitoOptions, RelativeSource={RelativeSource AncestorType=UserControl}}" SelectedItem="{Binding Esito}" />
+                            <TextBox Width="150" Text="{Binding Nota}" Margin="8,0,0,0" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <TextBlock Text="Ricambi" FontWeight="Bold" Margin="0,8,0,0" />
+            <DataGrid ItemsSource="{Binding Ricambi}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,0,0,8">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Codice" Binding="{Binding Codice}" />
+                    <DataGridTextColumn Header="Descrizione" Binding="{Binding Descrizione}" />
+                    <DataGridTextColumn Header="Qtà" Binding="{Binding Quantita}" />
+                    <DataGridTextColumn Header="Prezzo" Binding="{Binding PrezzoUnitario}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Text="Manodopera" FontWeight="Bold" />
+            <DataGrid ItemsSource="{Binding Manodopera}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,0,0,8">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Descrizione" Binding="{Binding Descrizione}" />
+                    <DataGridTextColumn Header="Ore" Binding="{Binding Ore}" />
+                    <DataGridTextColumn Header="Tariffa" Binding="{Binding Tariffa}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Text="Note" />
+            <TextBox Text="{Binding Intervento.Note}" AcceptsReturn="True" Height="60" Margin="0,0,0,8" />
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <StackPanel>
+                    <TextBlock Text="Firma tecnico" />
+                    <InkCanvas x:Name="TecnicoCanvas" Width="200" Height="100" Background="LightGray" />
+                </StackPanel>
+                <StackPanel Margin="16,0,0,0">
+                    <TextBlock Text="Firma cliente" />
+                    <InkCanvas x:Name="ClienteCanvas" Width="200" Height="100" Background="LightGray" />
+                </StackPanel>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Salva" Margin="0,0,8,0" Click="OnSave" />
+                <Button Content="Concludi" Click="OnConclude" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Maintenance.Client/Views/InterventoFormView.xaml.vb
+++ b/Maintenance.Client/Views/InterventoFormView.xaml.vb
@@ -1,0 +1,49 @@
+Imports System.IO
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Ink
+Imports System.Windows.Media
+Imports System.Windows.Media.Imaging
+Imports Maintenance.Client.ViewModels
+Imports Maintenance.Shared.Models
+
+Namespace Maintenance.Client.Views
+    Public Partial Class InterventoFormView
+        Inherits UserControl
+
+        Public Sub New(model As Intervento)
+            InitializeComponent()
+            DataContext = New InterventoFormViewModel(model)
+            If model.DataInizio = DateTime.MinValue Then
+                model.DataInizio = Date.Now
+                model.DataFine = Date.Now
+            End If
+        End Sub
+
+        Private Function CanvasToBase64(canvas As InkCanvas) As String
+            Dim bounds = New Rect(canvas.RenderSize)
+            Dim rtb As New RenderTargetBitmap(CInt(bounds.Width), CInt(bounds.Height), 96, 96, PixelFormats.Default)
+            rtb.Render(canvas)
+            Dim encoder As New PngBitmapEncoder()
+            encoder.Frames.Add(BitmapFrame.Create(rtb))
+            Using ms As New MemoryStream()
+                encoder.Save(ms)
+                Return Convert.ToBase64String(ms.ToArray())
+            End Using
+        End Function
+
+        Private Sub OnConclude(sender As Object, e As RoutedEventArgs)
+            Dim vm = TryCast(DataContext, InterventoFormViewModel)
+            Dim tech = CanvasToBase64(TecnicoCanvas)
+            Dim cli = CanvasToBase64(ClienteCanvas)
+            vm.Complete(tech, cli)
+            Dim win = Window.GetWindow(Me)
+            If win IsNot Nothing Then win.Close()
+        End Sub
+
+        Private Sub OnSave(sender As Object, e As RoutedEventArgs)
+            Dim vm = TryCast(DataContext, InterventoFormViewModel)
+            vm.SaveCommand.Execute(Nothing)
+        End Sub
+    End Class
+End Namespace

--- a/Maintenance.Client/Views/MainWindow.xaml
+++ b/Maintenance.Client/Views/MainWindow.xaml
@@ -23,6 +23,9 @@
         <DataTemplate DataType="{x:Type vm:SkillViewModel}">
             <views:SkillView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:InterventiListViewModel}">
+            <views:InterventiListView />
+        </DataTemplate>
     </Window.Resources>
     <Grid>
         <ContentControl Content="{Binding Navigation.CurrentViewModel}" />

--- a/Maintenance.Shared/Models/Intervento.vb
+++ b/Maintenance.Shared/Models/Intervento.vb
@@ -1,7 +1,8 @@
 Namespace Maintenance.Shared.Models
     Public Class Intervento
         Public Property Id As Integer
-        Public Property Data As DateTime
+        Public Property DataInizio As DateTime
+        Public Property DataFine As DateTime?
         Public Property Note As String
 
         Public Property TicketId As Integer

--- a/Maintenance.Shared/Models/InterventoCheck.vb
+++ b/Maintenance.Shared/Models/InterventoCheck.vb
@@ -6,7 +6,9 @@ Namespace Maintenance.Shared.Models
         Public Property CheckItemId As Integer
         Public Property CheckItem As CheckItem
 
-        Public Property Esito As Boolean
+        ' Esito puo' assumere valori "OK", "Da sostituire" oppure "Da monitorare"
+        Public Property Esito As String
+        Public Property Nota As String
     End Class
 End Namespace
 

--- a/Maintenance.Shared/Models/InterventoManodopera.vb
+++ b/Maintenance.Shared/Models/InterventoManodopera.vb
@@ -3,6 +3,7 @@ Namespace Maintenance.Shared.Models
         Public Property Id As Integer
         Public Property Descrizione As String
         Public Property Ore As Decimal
+        Public Property Tariffa As Decimal
 
         Public Property InterventoId As Integer
         Public Property Intervento As Intervento

--- a/Maintenance.Shared/Models/InterventoRicambi.vb
+++ b/Maintenance.Shared/Models/InterventoRicambi.vb
@@ -1,8 +1,10 @@
 Namespace Maintenance.Shared.Models
     Public Class InterventoRicambi
         Public Property Id As Integer
+        Public Property Codice As String
         Public Property Descrizione As String
         Public Property Quantita As Integer
+        Public Property PrezzoUnitario As Decimal
 
         Public Property InterventoId As Integer
         Public Property Intervento As Intervento


### PR DESCRIPTION
## Summary
- extend intervention models with new fields
- implement `InterventiListViewModel` and `InterventoFormViewModel`
- create `InterventiListView` and `InterventoFormView` with signature capture
- register new view in `MainWindow`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688381cac4748327889514e41ebbc62e